### PR TITLE
Fix FMJ + accesswidener crash

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -5,7 +5,9 @@
 
   "name": "ActionMobs",
   "description": "A mod that adds miniature games inspired mob model blocks to Minecraft.",
-  "authors": [],
+  "authors": [
+    "HyperPigeon"
+  ],
   "contact": {},
 
   "license": "MIT",
@@ -21,10 +23,12 @@
   "mixins": [
     "action_mobs.mixins.json"
   ],
+  "accessWidener": "action_mobs.accesswidener",
+
 
   "depends": {
     "fabricloader": ">=${loader_version}",
-    "fabric": "*",
+    "fabric-api": "*",
     "minecraft": "${minecraft_version}"
   }
 }


### PR DESCRIPTION
Fixes a few issues with your `fabric.mod.json`
- Author information not set
- Access widener not set (caused crash on ModFest: Toybox test server)
- Fabric API's namespace has been `fabric-api` since 1.19.3.